### PR TITLE
Disable Emacs grammar check

### DIFF
--- a/doom.d/init.el
+++ b/doom.d/init.el
@@ -82,7 +82,7 @@
        :checkers
        syntax              ; tasing you for every semicolon you forget
        ;;(spell +flyspell) ; tasing you for misspelling mispelling
-       grammar           ; tasing grammar mistake every you make
+       ;;grammar           ; tasing grammar mistake every you make
 
        :tools
        ;;ansible


### PR DESCRIPTION
The `grammar` option in doom-emacs was adding all kinds of difficult-to-read highlighting to READMEs. This may have been fixable with enough messing around with colours, but just disabling for now.